### PR TITLE
Format the docs/make.jl

### DIFF
--- a/docs/make.jl
+++ b/docs/make.jl
@@ -14,12 +14,7 @@ makedocs(;
         edit_link = "main",
         assets = String[],
     ),
-    pages = [
-        "Home" => "index.md",
-    ],
+    pages = ["Home" => "index.md"],
 )
 
-deploydocs(;
-    repo = "github.com/filtron/MarkovKernels.jl",
-    devbranch = "main",
-)
+deploydocs(; repo = "github.com/filtron/MarkovKernels.jl", devbranch = "main")


### PR DESCRIPTION
This file didn't exist in the JuliaFormatter PR, and I forgot to rebase the branch onto the latest main. So it didn't get formatted in that PR.