### PR TITLE
alias AffineNormalKernel defined

### DIFF
--- a/src/MarkovKernels.jl
+++ b/src/MarkovKernels.jl
@@ -46,7 +46,7 @@ include("kernels/normalkernel_generic.jl") # generic normal kernels
 include("kernels/dirackernel.jl") # defines dirac kernels
 include("kernels/compose.jl")
 export AbstractNormalKernel,
-    NormalKernel, AffineNormalKernel, condition, compose, marginalise, invert, DiracKernel
+    NormalKernel, AffineNormalKernel, AffineIsoNormalKernel, condition, compose, marginalise, invert, DiracKernel
 
 # general sampling functions for kernels and Markov processes
 include("sampling.jl")

--- a/src/MarkovKernels.jl
+++ b/src/MarkovKernels.jl
@@ -39,15 +39,14 @@ export AbstractNormal,
 
 # defines conditional mean for normal kernels
 include("kernels/affinemap.jl")
-export AbstractConditionalMean,
-    ConditionalMean, AbstractAffineMap, AffineMap, nin, nout, slope, intercept, compose
+export AbstractAffineMap, AffineMap, nin, nout, slope, intercept, compose
 
 include("kernels/normalkernel.jl") # defines normal kernels
 include("kernels/normalkernel_generic.jl") # generic normal kernels
 include("kernels/dirackernel.jl") # defines dirac kernels
 include("kernels/compose.jl")
 export AbstractNormalKernel,
-    NormalKernel, condition, compose, marginalise, invert, DiracKernel
+    NormalKernel, AffineNormalKernel, condition, compose, marginalise, invert, DiracKernel
 
 # general sampling functions for kernels and Markov processes
 include("sampling.jl")

--- a/src/MarkovKernels.jl
+++ b/src/MarkovKernels.jl
@@ -46,7 +46,14 @@ include("kernels/normalkernel_generic.jl") # generic normal kernels
 include("kernels/dirackernel.jl") # defines dirac kernels
 include("kernels/compose.jl")
 export AbstractNormalKernel,
-    NormalKernel, AffineNormalKernel, AffineIsoNormalKernel, condition, compose, marginalise, invert, DiracKernel
+    NormalKernel,
+    AffineNormalKernel,
+    AffineIsoNormalKernel,
+    condition,
+    compose,
+    marginalise,
+    invert,
+    DiracKernel
 
 # general sampling functions for kernels and Markov processes
 include("sampling.jl")

--- a/src/kernels/normalkernel.jl
+++ b/src/kernels/normalkernel.jl
@@ -23,8 +23,6 @@ end
 const AffineNormalKernel{T} =
     NormalKernel{T,<:AbstractAffineMap,<:Union{UniformScaling,AbstractMatrix}}
 
-const AffineIsoNormalKernel{T} = NormalKernel{T,<:AbstractAffineMap,<:UniformScaling}
-
 NormalKernel(Φ::AbstractMatrix, Σ) = NormalKernel(AffineMap(Φ), Σ)
 
 NormalKernel(Φ::AbstractMatrix, b::AbstractVector, Σ) = NormalKernel(AffineMap(Φ, b), Σ)

--- a/src/kernels/normalkernel.jl
+++ b/src/kernels/normalkernel.jl
@@ -23,12 +23,14 @@ end
 const AffineNormalKernel{T} =
     NormalKernel{T,<:AbstractAffineMap,<:Union{UniformScaling,AbstractMatrix}}
 
-"""
-    NormalKernel(Φ::AbstractMatrix, Σ::AbstractMatrix)
+const AffineIsoNormalKernel{T} = NormalKernel{T,<:AbstractAffineMap,<:UniformScaling}
 
-Creates a Normal kernel with linear conditional mean of slope Φ and covariance matrix Σ.
 """
-NormalKernel(Φ::AbstractMatrix, Σ::AbstractMatrix) = NormalKernel(AffineMap(Φ), Σ)
+    NormalKernel(Φ::AbstractMatrix, Σ)
+
+Creates a Normal kernel with linear conditional mean of slope Φ and covariance parameter Σ.
+"""
+NormalKernel(Φ::AbstractMatrix, Σ) = NormalKernel(AffineMap(Φ), Σ)
 
 """
     NormalKernel(Φ::AbstractMatrix, b::AbstractVector, Σ::AbstractMatrix)
@@ -46,7 +48,7 @@ NormalKernel(
 
 mean(K::NormalKernel) = K.μ
 
-cov(K::NormalKernel{T,U,V}) where {T,U,V<:AbstractMatrix} = K.Σ
+cov(K::NormalKernel) = K.Σ
 
 condition(K::NormalKernel, x) = Normal(mean(K)(x), cov(K))
 

--- a/src/kernels/normalkernel.jl
+++ b/src/kernels/normalkernel.jl
@@ -25,26 +25,11 @@ const AffineNormalKernel{T} =
 
 const AffineIsoNormalKernel{T} = NormalKernel{T,<:AbstractAffineMap,<:UniformScaling}
 
-"""
-    NormalKernel(Φ::AbstractMatrix, Σ)
-
-Creates a Normal kernel with linear conditional mean of slope Φ and covariance parameter Σ.
-"""
 NormalKernel(Φ::AbstractMatrix, Σ) = NormalKernel(AffineMap(Φ), Σ)
 
-"""
-    NormalKernel(Φ::AbstractMatrix, b::AbstractVector, Σ::AbstractMatrix)
-
-Creates a Normal kernel with affine conditional mean of slope Φ, intercept b, and covariance matrix Σ.
-"""
-NormalKernel(Φ::AbstractMatrix, b::AbstractVector, Σ::AbstractMatrix) =
-    NormalKernel(AffineMap(Φ, b), Σ)
-NormalKernel(
-    Φ::AbstractMatrix,
-    b::AbstractVector,
-    pred::AbstractVector,
-    Σ::AbstractMatrix,
-) = NormalKernel(AffineMap(Φ, b, pred), Σ)
+NormalKernel(Φ::AbstractMatrix, b::AbstractVector, Σ) = NormalKernel(AffineMap(Φ, b), Σ)
+NormalKernel(Φ::AbstractMatrix, b::AbstractVector, pred::AbstractVector, Σ) =
+    NormalKernel(AffineMap(Φ, b, pred), Σ)
 
 mean(K::NormalKernel) = K.μ
 

--- a/src/matrix_utilities.jl
+++ b/src/matrix_utilities.jl
@@ -12,11 +12,10 @@ lsqrt(m::UniformScaling) = sqrt(m)
 
 # stein operator
 stein(Σ, Φ) = Matrix(Hermitian(Φ * Σ * Φ'))
-stein(Σ::T, Φ::T) where T <: UniformScaling = Φ * Σ * Φ'
+stein(Σ::T, Φ::T) where {T<:UniformScaling} = Φ * Σ * Φ'
 
-stein(Σ, Φ, Q) =
-    Matrix(Hermitian(Φ * Σ * Φ' + Q))
-stein(Σ::T, Φ::T, Q::T) where T <: UniformScaling = Φ * Σ * Φ' + Q
+stein(Σ, Φ, Q) = Matrix(Hermitian(Φ * Σ * Φ' + Q))
+stein(Σ::T, Φ::T, Q::T) where {T<:UniformScaling} = Φ * Σ * Φ' + Q
 
 stein(Σ, A::AbstractAffineMap) = stein(Σ, slope(A))
 stein(Σ, A::AbstractAffineMap, Q) = stein(Σ, slope(A), Q)

--- a/src/matrix_utilities.jl
+++ b/src/matrix_utilities.jl
@@ -11,14 +11,18 @@ lsqrt(m::AbstractMatrix) = cholesky(m).L
 lsqrt(m::UniformScaling) = sqrt(m)
 
 # stein operator
-stein(Σ::AbstractMatrix, Φ::AbstractMatrix) = Matrix(Hermitian(Φ * Σ * Φ'))
-stein(Σ::AbstractMatrix, Φ::AbstractMatrix, Q::AbstractMatrix) =
+stein(Σ, Φ) = Matrix(Hermitian(Φ * Σ * Φ'))
+stein(Σ::T, Φ::T) where T <: UniformScaling = Φ * Σ * Φ'
+
+stein(Σ, Φ, Q) =
     Matrix(Hermitian(Φ * Σ * Φ' + Q))
-stein(Σ::AbstractMatrix, A::AbstractAffineMap) = stein(Σ, slope(A))
-stein(Σ::AbstractMatrix, A::AbstractAffineMap, Q::AbstractMatrix) = stein(Σ, slope(A), Q)
+stein(Σ::T, Φ::T, Q::T) where T <: UniformScaling = Φ * Σ * Φ' + Q
+
+stein(Σ, A::AbstractAffineMap) = stein(Σ, slope(A))
+stein(Σ, A::AbstractAffineMap, Q) = stein(Σ, slope(A), Q)
 
 # schur reduction
-function schur_red(Π::AbstractMatrix, C, R)
+function schur_red(Π, C, R)
     K = Π * C'
     S = Hermitian(C * K + R)
 
@@ -32,4 +36,4 @@ function schur_red(Π::AbstractMatrix, C, R)
     return Matrix(S), K, Matrix(Σ)
 end
 
-schur_red(Π::AbstractMatrix, C) = schur_red(Π, C, 0.0 * I) # might be done smarter?
+schur_red(Π, C) = schur_red(Π, C, 0.0 * I) # might be done smarter?

--- a/test/normalkernel_test.jl
+++ b/test/normalkernel_test.jl
@@ -44,6 +44,8 @@ function normalkernel_test(T, n)
 
         @test slope(mean(compose(K2, K1))) ≈ slope(K3.μ)
         @test cov(compose(K2, K1)) ≈ cov(K3)
+        @test slope(mean(K2 * K1)) == slope(mean(compose(K2, K1)))
+        @test cov(K2 * K1) == cov(compose(K2, K1))
 
         @test mean(marginalise(N1, K1)) ≈ Φ1 * μ
         @test cov(marginalise(N1, K1)) ≈ Hermitian(Φ1 * Σ * Φ1' + Q1)

--- a/test/normalkernel_test.jl
+++ b/test/normalkernel_test.jl
@@ -79,7 +79,6 @@ function normalkernel_test(T, n)
     K4 = NormalKernel(Φ2 * Φ1, Hermitian(Φ2 * λ2 * Φ2' + λ3 * I))
 
     @testset "AffineIsoNormalKernel | $(T) " begin
-        @test typeof(IK1) <: AffineIsoNormalKernel
         @test mean(IK1)(x) == Φ1 * x
         @test cov(IK1) == λ2 * I
 

--- a/test/normalkernel_test.jl
+++ b/test/normalkernel_test.jl
@@ -55,9 +55,9 @@ function normalkernel_test(T, n)
     end
 
     λ1 = 2.0
-    IN1 = IsoNormal(μ,λ1)
+    IN1 = IsoNormal(μ, λ1)
 
-    pred, S, G, Π = _schur(λ1*I, μ, Φ1, Q1)
+    pred, S, G, Π = _schur(λ1 * I, μ, Φ1, Q1)
     N_gt2 = Normal(pred, S)
     corrector = AffineMap(G, μ, pred)
     K_gt2 = NormalKernel(corrector, Π)
@@ -65,7 +65,6 @@ function normalkernel_test(T, n)
     NC2, KC2 = invert(IN1, K1)
 
     @testset "AffineNormalKernel / IsoNormal | $(T) " begin
-
         @test mean(marginalise(IN1, K1)) ≈ Φ1 * μ
         @test cov(marginalise(IN1, K1)) ≈ Hermitian(Φ1 * λ1 * Φ1' + Q1)
 
@@ -75,14 +74,12 @@ function normalkernel_test(T, n)
         @test slope(mean(KC2)) ≈ slope(mean(K_gt2))
         @test intercept(mean(KC2)) ≈ intercept(mean(K_gt2))
     end
-
 end
 
-function _schur(Σ, μ, C,R)
-
+function _schur(Σ, μ, C, R)
     pred = C * μ
-  #  dimx = length(μ)
-   # dimy = length(pred)
+    #  dimx = length(μ)
+    # dimy = length(pred)
 
     S = Hermitian(C * Σ * C' + R)
     G = Σ * C' / S


### PR DESCRIPTION
Making alias AffineNormalKernel for NormalKernel that admit exact inference + changing function definitions to conform to this. 