### PR TITLE
Make sym explicit

### DIFF
--- a/src/MarkovKernels.jl
+++ b/src/MarkovKernels.jl
@@ -8,8 +8,11 @@ import LinearAlgebra: logdet, norm_sqr, HermOrSym
 import Statistics: mean, cov, var, std
 import Random: rand, GLOBAL_RNG
 
-const CovarianceParameter{T} = Union{HermOrSym{T},UniformScaling{T},Factorization{T}} 
-const DiagonalCovarianceParameter{T, V} = Union{Symmetric{T,Diagonal{T,V}},Hermitian{T,Diagonal{T,V}}}
+const CovarianceParameter{T} = Union{HermOrSym{T},UniformScaling{T},Factorization{T}}
+
+# maybe not needed
+#const DiagonalCovarianceParameter{T,V} =
+#    Union{Symmetric{T,Diagonal{T,V}},Hermitian{T,Diagonal{T,V}}}
 
 for P in (:UniformScaling, :Factorization)
     @eval CovarianceParameter{T}(Σ::$P) where {T} = convert($P{T}, Σ)

--- a/src/MarkovKernels.jl
+++ b/src/MarkovKernels.jl
@@ -11,8 +11,9 @@ import Random: rand, GLOBAL_RNG
 const CovarianceParameter{T} = Union{AbstractMatrix{T},UniformScaling{T},Factorization{T}}
 for P in (:AbstractMatrix, :UniformScaling, :Factorization)
     @eval CovarianceParameter{T}(Σ::$P) where {T} = convert($P{T}, Σ)
-    @eval convert(::Type{CovarianceParameter{T}}, Σ::$P) where {T} = convert($P{T}, Σ)
 end
+convert(::Type{CovarianceParameter{T}}, Σ::CovarianceParameter) where {T} =
+    CovarianceParameter{T}(Σ)
 
 export CovarianceParameter
 

--- a/src/MarkovKernels.jl
+++ b/src/MarkovKernels.jl
@@ -4,18 +4,22 @@ using LinearAlgebra, Statistics, Random, RecipesBase
 
 import Base: *, +, eltype, length, size, log, ==, similar, convert
 
-import LinearAlgebra: logdet, norm_sqr
+import LinearAlgebra: logdet, norm_sqr, HermOrSym
 import Statistics: mean, cov, var, std
 import Random: rand, GLOBAL_RNG
 
-const CovarianceParameter{T} = Union{AbstractMatrix{T},UniformScaling{T},Factorization{T}}
-for P in (:AbstractMatrix, :UniformScaling, :Factorization)
+const CovarianceParameter{T} = Union{HermOrSym{T},UniformScaling{T},Factorization{T}} 
+const DiagonalCovarianceParameter{T, V} = Union{Symmetric{T,Diagonal{T,V}},Hermitian{T,Diagonal{T,V}}}
+
+for P in (:UniformScaling, :Factorization)
     @eval CovarianceParameter{T}(Σ::$P) where {T} = convert($P{T}, Σ)
 end
+CovarianceParameter{T}(Σ::HermOrSym) where {T} = convert(AbstractMatrix{T}, Σ)
+
 convert(::Type{CovarianceParameter{T}}, Σ::CovarianceParameter) where {T} =
     CovarianceParameter{T}(Σ)
 
-export CovarianceParameter
+export CovarianceParameter, DiagonalCovarianceParameter
 
 abstract type AbstractDistribution{T<:Number} end
 
@@ -79,4 +83,6 @@ include("sampling.jl")
 
 # helper functions
 include("matrix_utilities.jl")
+export lsqrt, stein, schur_reduce
+
 end

--- a/src/MarkovKernels.jl
+++ b/src/MarkovKernels.jl
@@ -8,6 +8,14 @@ import LinearAlgebra: logdet, norm_sqr
 import Statistics: mean, cov, var, std
 import Random: rand, GLOBAL_RNG
 
+const CovarianceParameter{T} = Union{AbstractMatrix{T},UniformScaling{T},Factorization{T}}
+for P in (:AbstractMatrix, :UniformScaling, :Factorization)
+    @eval CovarianceParameter{T}(Σ::$P) where {T} = convert($P{T}, Σ)
+    @eval convert(::Type{CovarianceParameter{T}}, Σ::$P) where {T} = convert($P{T}, Σ)
+end
+
+export CovarianceParameter
+
 abstract type AbstractDistribution{T<:Number} end
 
 eltype(::AbstractDistribution{T}) where {T} = T

--- a/src/distributions/dirac.jl
+++ b/src/distributions/dirac.jl
@@ -10,11 +10,12 @@ struct Dirac{T,U} <: AbstractDirac{T}
 end
 
 Dirac(μ::AbstractVector) = Dirac{eltype(μ)}(μ)
-
 Dirac{T}(D::Dirac{U,V}) where {T,U,V<:AbstractVector} =
-    T <: Real && U <: Real || T <: Complex && U <: Complex ?
+    all(x -> x <: Real, (T, U)) || all(x -> x <: Complex, (T, U)) ?
     Dirac(convert(AbstractVector{T}, D.μ)) :
-    error("T and U must both be complex or both be real")
+    error(
+        "The constructor type $(T) and the argument type $(U) must both be real or both be complex",
+    )
 
 AbstractDistribution{T}(D::AbstractDirac) where {T} = AbstractDirac{T}(D)
 AbstractDirac{T}(D::AbstractDirac{T}) where {T} = D

--- a/src/distributions/dirac.jl
+++ b/src/distributions/dirac.jl
@@ -11,7 +11,7 @@ end
 
 Dirac(μ::AbstractVector) = Dirac{eltype(μ)}(μ)
 Dirac{T}(D::Dirac{U,V}) where {T,U,V<:AbstractVector} =
-    all(x -> x <: Real, (T, U)) || all(x -> x <: Complex, (T, U)) ?
+    T <: Real && U <: Real || T <: Complex && U <: Complex ?
     Dirac(convert(AbstractVector{T}, D.μ)) :
     error(
         "The constructor type $(T) and the argument type $(U) must both be real or both be complex",

--- a/src/distributions/normal.jl
+++ b/src/distributions/normal.jl
@@ -19,9 +19,14 @@ struct Normal{T,U,V} <: AbstractNormal{T}
     Normal{T}(μ, Σ) where {T} = new{T,typeof(μ),typeof(Σ)}(μ, Σ)
 end
 
-# can currently create Complex valued Normal with symmetric covariance, this is bad
 function Normal(μ::AbstractVector, Σ::CovarianceParameter)
     T = promote_type(eltype(μ), eltype(Σ))
+    return Normal{T}(convert(AbstractVector{T}, μ), convert(CovarianceParameter{T}, Σ))
+end
+
+function Normal(μ::AbstractVector, Σ::Symmetric)
+    T = promote_type(eltype(μ), eltype(Σ))
+    T <: Complex && throw(DomainError(Σ, "Complex valued covariance must be Hermitian"))
     return Normal{T}(convert(AbstractVector{T}, μ), convert(CovarianceParameter{T}, Σ))
 end
 

--- a/src/distributions/normal.jl
+++ b/src/distributions/normal.jl
@@ -19,22 +19,22 @@ struct Normal{T,U,V} <: AbstractNormal{T}
     Normal{T}(μ, Σ) where {T} = new{T,typeof(μ),typeof(Σ)}(μ, Σ)
 end
 
+# can currently create Complex valued Normal with symmetric covariance, this is bad
 function Normal(μ::AbstractVector, Σ::CovarianceParameter)
     T = promote_type(eltype(μ), eltype(Σ))
     return Normal{T}(convert(AbstractVector{T}, μ), convert(CovarianceParameter{T}, Σ))
 end
 
 function Normal(μ::AbstractVector, Σ::AbstractMatrix)
-    T = promote_type(eltype(μ), eltype(Σ)) 
-    if T<:Real  
-        issymmetric(Σ) &&  return Normal(μ, Symmetric(Σ))
-        error("Normal of eltype $(T) must have symmetric covariance $(Σ)")
-    elseif T<:Complex  
-        ishermitian(Σ) && return Normal(μ, Hermitian(Σ)) 
-        error("Normal of eltype $(T) must have Hermitian covariance $(Σ)")
+    T = promote_type(eltype(μ), eltype(Σ))
+    if T <: Real
+        issymmetric(Σ) && return Normal(μ, Symmetric(Σ))
+        throw(DomainError(Σ, "Real valued covariance must be symmetric"))
+    elseif T <: Complex
+        ishermitian(Σ) && return Normal(μ, Hermitian(Σ))
+        throw(DomainError(Σ, "Complex valued covariance must be Hermitian"))
     end
 end
-
 
 function Normal{T}(N::Normal{U,V,W}) where {T,U,V<:AbstractVector,W<:CovarianceParameter}
     T <: Real && U <: Real || T <: Complex && U <: Complex ?

--- a/src/invert.jl
+++ b/src/invert.jl
@@ -7,7 +7,7 @@ P(y,x) = Nout(y)*Kout(x,y)
 """
 function invert(N::AbstractNormal{T}, K::AffineNormalKernel{T}) where {T}
     pred = mean(K)(mean(N))
-    S, G, Σ = schur_red(covp(N), mean(K), covp(K))
+    S, G, Σ = schur_reduce(covp(N), mean(K), covp(K))
 
     Nout = Normal(pred, S)
     Kout = NormalKernel(AffineCorrector(G, mean(N), pred), Σ)
@@ -17,7 +17,7 @@ end
 
 function invert(N::AbstractNormal{T}, K::AffineDiracKernel{T}) where {T}
     pred = mean(K)(mean(N))
-    S, G, Σ = schur_red(covp(N), mean(K))
+    S, G, Σ = schur_reduce(covp(N), mean(K))
 
     Nout = Normal(pred, S)
     Kout = NormalKernel(AffineCorrector(G, mean(N), pred), Σ)

--- a/src/kernels/normalkernel.jl
+++ b/src/kernels/normalkernel.jl
@@ -35,6 +35,15 @@ function NormalKernel(F::AbstractAffineMap, Σ::CovarianceParameter)
     )
 end
 
+function NormalKernel(F::AbstractAffineMap, Σ::Symmetric)
+    T = promote_type(eltype(F), eltype(Σ))
+    T <: Complex && throw(DomainError(Σ, "Complex valued covariance must be Hermitian"))
+    return NormalKernel{T}(
+        convert(AbstractAffineMap{T}, F),
+        convert(CovarianceParameter{T}, Σ),
+    )
+end
+
 function NormalKernel(F::AbstractAffineMap, Σ::AbstractMatrix)
     T = promote_type(eltype(F), eltype(Σ))
     if T <: Real

--- a/src/kernels/normalkernel.jl
+++ b/src/kernels/normalkernel.jl
@@ -33,6 +33,17 @@ function NormalKernel(F::AbstractAffineMap, Σ::CovarianceParameter)
         convert(AbstractAffineMap{T}, F),
         convert(CovarianceParameter{T}, Σ),
     )
+end 
+
+function NormalKernel(F::AbstractAffineMap, Σ::AbstractMatrix)
+    T = promote_type(eltype(F), eltype(Σ)) 
+    if T<:Real  
+        issymmetric(Σ) &&  return NormalKernel(F, Symmetric(Σ))
+        error("NormalKernel of eltype $(T) must have symmetric covariance $(Σ)")
+    elseif T<:Complex  
+        ishermitian(Σ) && return NormalKernel(F, Hermitian(Σ)) 
+        error("NormalKernel of eltype $(T) must have Hermitian covariance $(Σ)")
+    end
 end
 
 function NormalKernel{T}(K::AffineNormalKernel{U}) where {T,U}

--- a/src/kernels/normalkernel.jl
+++ b/src/kernels/normalkernel.jl
@@ -33,16 +33,16 @@ function NormalKernel(F::AbstractAffineMap, Σ::CovarianceParameter)
         convert(AbstractAffineMap{T}, F),
         convert(CovarianceParameter{T}, Σ),
     )
-end 
+end
 
 function NormalKernel(F::AbstractAffineMap, Σ::AbstractMatrix)
-    T = promote_type(eltype(F), eltype(Σ)) 
-    if T<:Real  
-        issymmetric(Σ) &&  return NormalKernel(F, Symmetric(Σ))
-        error("NormalKernel of eltype $(T) must have symmetric covariance $(Σ)")
-    elseif T<:Complex  
-        ishermitian(Σ) && return NormalKernel(F, Hermitian(Σ)) 
-        error("NormalKernel of eltype $(T) must have Hermitian covariance $(Σ)")
+    T = promote_type(eltype(F), eltype(Σ))
+    if T <: Real
+        issymmetric(Σ) && return NormalKernel(F, Symmetric(Σ))
+        throw(DomainError(Σ, "Real valued covariance must be symmetric"))
+    elseif T <: Complex
+        ishermitian(Σ) && return NormalKernel(F, Hermitian(Σ))
+        throw(DomainError(Σ, "Complex valued covariance must be Hermitian"))
     end
 end
 

--- a/src/matrix_utilities.jl
+++ b/src/matrix_utilities.jl
@@ -3,20 +3,7 @@ function LinearAlgebra.logdet(H::Hermitian)
     resign = real(sign)
     return mag + log(resign)
 end
-
-"""
-rlogdet(A)  
-
-Equivalent to logdet(A) if A is Hermitian. 
-Throws InexactError if the sign of the determinant can not be converted to a real type. 
-Throws DomainError if the real value of the sign is non-positive. 
-"""
-rlogdet(A) = logdet(A)
-rlogdet(H::Hermitian) = logdet(H)
-function rlogdet(A::AbstractMatrix{T}) where {T}
-    mag, sign = logabsdet(A)
-    return mag + log(convert(real(T), sign))
-end
+LinearAlgebra.logdet(H::HermOrSym{T,<:Diagonal}) where {T} = real(logdet(parent(H)))
 
 """
     rsqrt2cholU(pre_array::AbstractMatrix)

--- a/src/matrix_utilities.jl
+++ b/src/matrix_utilities.jl
@@ -69,7 +69,7 @@ _stein(Σ, Φ, Q::Cholesky) = _stein(Σ, Φ, symmetrise(AbstractMatrix(Q)))
 _stein_chol(Σ, Φ, Q) = Cholesky(rsqrt2cholU([lsqrt(Σ)' * Φ'; lsqrt(Q)']))
 
 """
-    schur_red(Π, C, R)
+    schur_reduce(Π, C, R)
 
 Returns the tuple (S, K, Σ) associated with the following (block) Schur reduction:
 
@@ -80,19 +80,20 @@ where S = C*Π*C' + R.
 In terms of Kalman filtering, if Π is the predictive covariance, C the measurement matrix, and R the measurement covariance,
 then S is the marginal measurement covariance, K is the Kalman gain, and Σ is the filtering covariance.
 
-    schur_red(Π, C)
+    schur_reduce(Π, C)
 
 Mathematically, the same as schur_red(Π, C, R) for R = 0
 """
-schur_red(Π, C::AbstractMatrix) = _schur_red(Π, C)
-schur_red(Π, C::AbstractMatrix, R) = _schur_red(Π, C, R)
+schur_reduce(Π, C::AbstractMatrix) = _schur_red(Π, C)
+schur_reduce(Π, C::AbstractMatrix, R) = _schur_red(Π, C, R)
 
-schur_red(Π::Cholesky, C::AbstractMatrix) = _schur_red_chol(Π, C)
-schur_red(Π::Cholesky, C::AbstractMatrix, R) = _schur_red_chol(Π, C, R)
-schur_red(Π::CholeskyCompatible, C::AbstractMatrix, R::Cholesky) = _schur_red_chol(Π, C, R)
+schur_reduce(Π::Cholesky, C::AbstractMatrix) = _schur_red_chol(Π, C)
+schur_reduce(Π::Cholesky, C::AbstractMatrix, R) = _schur_red_chol(Π, C, R)
+schur_reduce(Π::CholeskyCompatible, C::AbstractMatrix, R::Cholesky) =
+    _schur_red_chol(Π, C, R)
 
-schur_red(Π, C::AbstractAffineMap) = schur_red(Π, slope(C))
-schur_red(Π, C::AbstractAffineMap, R) = schur_red(Π, slope(C), R)
+schur_reduce(Π, C::AbstractAffineMap) = schur_reduce(Π, slope(C))
+schur_reduce(Π, C::AbstractAffineMap, R) = schur_reduce(Π, slope(C), R)
 
 function _schur_red(Π, C)
     K = Π * C'

--- a/src/matrix_utilities.jl
+++ b/src/matrix_utilities.jl
@@ -39,10 +39,8 @@ lsqrt(J::UniformScaling) = sqrt(J)
 lsqrt(C::Cholesky) = C.L
 
 # project matrix onto symmetric matrix
+symmetrise(Σ) = Σ
 symmetrise(Σ::AbstractMatrix{T}) where {T} = T <: Real ? Symmetric(Σ) : Hermitian(Σ)
-symmetrise(Σ::Diagonal) = Σ
-symmetrise(Σ::UniformScaling) = Σ
-symmetrise(C::Cholesky) = C
 
 const CholeskyCompatible = Union{Diagonal,UniformScaling}
 

--- a/src/matrix_utilities.jl
+++ b/src/matrix_utilities.jl
@@ -1,9 +1,21 @@
-
-# fix logdet for Hermitian matrices
 function LinearAlgebra.logdet(H::Hermitian)
     mag, sign = logabsdet(H)
     resign = real(sign)
     return mag + log(resign)
+end
+
+"""
+rlogdet(A)  
+
+Equivalent to logdet(A) if A is Hermitian. 
+Throws InexactError if the sign of the determinant can not be converted to a real type. 
+Throws DomainError if the real value of the sign is non-positive. 
+"""
+rlogdet(A) = logdet(A)
+rlogdet(H::Hermitian) = logdet(H)
+function rlogdet(A::AbstractMatrix{T}) where {T}
+    mag, sign = logabsdet(A)
+    return mag + log(convert(real(T), sign))
 end
 
 """
@@ -42,7 +54,7 @@ Computes the output of the stein  operator
 
     stein(Σ, Φ)
 
-Same as stein(Σ, Φ, 0.0I)
+Mathematically, the same as stein(Σ, Φ, R) for R = 0.
 """
 stein(Σ, Φ::AbstractMatrix) = symmetrise(Φ * Σ * Φ')
 stein(Σ, Φ::AbstractMatrix, Q) = _stein(Σ, Φ, Q)

--- a/src/matrix_utilities.jl
+++ b/src/matrix_utilities.jl
@@ -18,15 +18,18 @@ end
 
 """
     lsqrt(A) 
-returns a 'matrix' L such that A = L*L'. 
+returns a square 'matrix' L such that A = L*L'. 
 L need not be a Cholesky factor.   
 """
 lsqrt(A::AbstractMatrix) = cholesky(A).L
 lsqrt(J::UniformScaling) = sqrt(J)
 lsqrt(C::Cholesky) = C.L
 
-# project matrix onto symmetric matrix
-symmetrise(Σ) = Σ
+"""
+    symmetrise(Σ::AbstractMatrix{T}) 
+
+Wraps Σ in a Symmetric or Hermitian matrix for T<:Real and T<:Complex, respectively. 
+"""
 symmetrise(Σ::AbstractMatrix{T}) where {T} = T <: Real ? Symmetric(Σ) : Hermitian(Σ)
 
 const CholeskyCompatible = Union{Diagonal,UniformScaling}
@@ -60,9 +63,7 @@ _stein_chol(Σ, Φ, Q) = Cholesky(rsqrt2cholU([lsqrt(Σ)' * Φ'; lsqrt(Q)']))
 
 Returns the tuple (S, K, Σ) associated with the following (block) Schur reduction:
 
-[S C*Π; Π*C' Π] = [0 0; 0 Σ] + [I; K]*S*[I K']
-
-where S = C*Π*C' + R.
+[C*Π*C' + R C*Π; Π*C' Π] = [0 0; 0 Σ] + [I; K]*(C*Π*C' + R)*[I; K]'
 
 In terms of Kalman filtering, if Π is the predictive covariance, C the measurement matrix, and R the measurement covariance,
 then S is the marginal measurement covariance, K is the Kalman gain, and Σ is the filtering covariance.

--- a/test/distributions/normal_test.jl
+++ b/test/distributions/normal_test.jl
@@ -8,6 +8,11 @@ function normal_test(T, n, cov_types)
 
     eltypes = T <: Real ? (Float32, Float64) : (ComplexF32, ComplexF64)
 
+    @testset "Normal | AbstractMatrix constructor" begin
+        @test_throws DomainError Normal(ones(2), tril(ones(2, 2)))
+        @test_throws DomainError Normal(ones(ComplexF64, 2), tril(ones(2, 2)))
+    end
+
     @testset "Normal | Unary | $(T)" begin
         @test IsoNormal(x, one(real(T))) == Normal(x, one(T) * I)
 

--- a/test/distributions/normal_test.jl
+++ b/test/distributions/normal_test.jl
@@ -11,6 +11,7 @@ function normal_test(T, n, cov_types)
     @testset "Normal | AbstractMatrix constructor" begin
         @test_throws DomainError Normal(ones(2), tril(ones(2, 2)))
         @test_throws DomainError Normal(ones(ComplexF64, 2), tril(ones(2, 2)))
+        @test_throws DomainError Normal(ones(ComplexF64, 2), Symmetric(diagm(ones(2))))
     end
 
     @testset "Normal | Unary | $(T)" begin

--- a/test/kernels/normalkernel_test.jl
+++ b/test/kernels/normalkernel_test.jl
@@ -15,6 +15,11 @@ function normalkernel_test(T, affine_types)
 end
 
 function affine_normalkernel_test(T, n, affine_types, cov_types)
+    @testset "NormalKernel | AbstractMatrix constructor" begin
+        @test_throws DomainError NormalKernel(ones(2, 2), tril(ones(2, 2)))
+        @test_throws DomainError NormalKernel(ones(ComplexF64, 2, 2), tril(ones(2, 2)))
+    end
+
     kernel_type_parameters = Iterators.product(affine_types, cov_types)
 
     for ts in kernel_type_parameters

--- a/test/kernels/normalkernel_test.jl
+++ b/test/kernels/normalkernel_test.jl
@@ -18,6 +18,10 @@ function affine_normalkernel_test(T, n, affine_types, cov_types)
     @testset "NormalKernel | AbstractMatrix constructor" begin
         @test_throws DomainError NormalKernel(ones(2, 2), tril(ones(2, 2)))
         @test_throws DomainError NormalKernel(ones(ComplexF64, 2, 2), tril(ones(2, 2)))
+        @test_throws DomainError NormalKernel(
+            ones(ComplexF64, 2, 2),
+            Symmetric(diagm(ones(2))),
+        )
     end
 
     kernel_type_parameters = Iterators.product(affine_types, cov_types)


### PR DESCRIPTION
1. Enforcing Symmetric / Hermitian for covariance matrices of type AbstractMatrix turns out to be necessary.
2. Compromise is to define: 

`const CovarianceParameter{T} = Union{Symmetric{T}, Hermitian{T}, UniformScaling{T}, Factorization{T}} where {T}` 

and add AbstractMatrix constructors for Normal / NormalKernel that check that the covariance is sym/herm before wrapping. 