### PR TITLE
homoskedastic normalkernel draft

### DIFF
--- a/src/MarkovKernels.jl
+++ b/src/MarkovKernels.jl
@@ -80,6 +80,8 @@ include("kernels/normalkernel.jl") # defines normal kernels
 include("kernels/dirackernel.jl") # defines dirac kernels
 export AbstractNormalKernel,
     NormalKernel,
+    HomoskedasticNormalKernel,
+    AffineHomoskedasticNormalKernel,
     AffineNormalKernel,
     condition,
     AbstractDiracKernel,

--- a/src/binary_operations/algebra.jl
+++ b/src/binary_operations/algebra.jl
@@ -4,8 +4,8 @@
 """
 -(D::AbstractDistribution)
 
-Computes the image distribution of D under negation, i.e. if 
-x ∼ D then -x ∼ -D. 
+Computes the image distribution of D under negation, i.e. if
+x ∼ D then -x ∼ -D.
 """
 -(N::Normal) = Normal(-mean(N), covp(N)) # should techically be in src/distributions
 -(D::Dirac) = Dirac(-mean(D)) # should techically be in src/distributions
@@ -14,7 +14,7 @@ x ∼ D then -x ∼ -D.
 +(v::AbstractNumOrVec, D::AbstractDistribution)
 +(D::AbstractDistribution, v::AbstractNumOrVec)
 
-Computes a translation of D by v, i.e. if 
+Computes a translation of D by v, i.e. if
 x ∼ D then x + v ∼ D + v.
 """
 +(D::AbstractDistribution, v::AbstractNumOrVec) = +(v, D)
@@ -34,7 +34,7 @@ Equivalent to +(D, -v).
 """
     *(C::AbstractMatrix{T}, D::AbstractDistribution{T})
 
-Equivalent to marginalize(D, DiracKernel(C)). 
+Equivalent to marginalize(D, DiracKernel(C)).
 """
 *(C::AbstractMatrix{T}, D::AbstractDistribution{T}) where {T} =
-    marginalize(D, DiracKernel(C))
+    marginalize(D, DiracKernel(LinearMap(C)))

--- a/src/binary_operations/compose.jl
+++ b/src/binary_operations/compose.jl
@@ -24,9 +24,9 @@ compose(K2::AffineDiracKernel{T}, K1::AffineNormalKernel{T}) where {T} =
 
 compose(K2::AbstractMarkovKernel, ::IdentityKernel) = K2
 compose(::IdentityKernel, K1::AbstractMarkovKernel) = K1
-compose(K2::IdentityKernel, ::IdentityKernel) = K2 # tie-breaker
+compose(K2::IdentityKernel, ::IdentityKernel) = K2
 
-""" 
+"""
     ∘(K2::AbstractMarkovKernel, K1::AbstractMarkovKernel)
 
 Computes K3, the composition of K2 ∘ K1 i.e.,

--- a/src/covariance_parameters/real.jl
+++ b/src/covariance_parameters/real.jl
@@ -2,14 +2,14 @@
 """
     rsqrt(x::Real)
 
-Computes the right-square root of x. 
+Computes the right-square root of x.
 """
 rsqrt(x::Real) = sqrt(x)
 
 """
     lsqrt(x::Real)
 
-Computes the right-square root of x. 
+Computes the right-square root of x.
 """
 lsqrt(x::Real) = rsqrt(x)
 
@@ -42,7 +42,7 @@ In terms of Kalman filtering, Π is the predictive covariance, C the measurement
 then S is the marginal measurement covariance, K is the Kalman gain, and Σ is the filtering covariance.
 """
 function schur_reduce(Π::Real, C::Number)
-    # this probably breaks if iszero(C) returns true 
+    # this probably breaks if iszero(C) returns true
     S = abs2(C) * Π
     K = Π * adjoint(C) / S
     L = (I - K * C)
@@ -61,7 +61,7 @@ In terms of Kalman filtering, Π is the predictive covariance, C the measurement
 then S is the marginal measurement covariance, K is the Kalman gain, and Σ is the filtering covariance.
 """
 function schur_reduce(Π::Real, C::Number, R::Real)
-    # this probably breaks if iszero(C) && iszero(R) returns true 
+    # this probably breaks if iszero(C) && iszero(R) returns true
     S = abs2(C) * Π + R
     K = Π * adjoint(C) / S
     L = (I - K * C)

--- a/src/covariance_parameters/selfadjoint.jl
+++ b/src/covariance_parameters/selfadjoint.jl
@@ -2,38 +2,26 @@ const RealSymmetric{T,S} = Symmetric{T,S} where {T<:Real,S}
 const ComplexHermitian{T,S} = Hermitian{T,S} where {T<:Complex,S}
 const SelfAdjoint{T,S} = Union{RealSymmetric{T,S},ComplexHermitian{T,S}} where {T,S}
 
-"""
-    selfadjoint(x::Number)
-
-Computes the self-adjoint part of the input  (real part). 
-"""
-selfadjoint(x::Number) = real(x)
-
-"""
-    selfadjoint(A::AbstractMatrix{<:Real})
-
-Wraps the input in Symmetric. 
-"""
-selfadjoint(A::AbstractMatrix{<:Real}) = Symmetric(A)
+selfadjoint(::Type{T}, x::Number) where {T} = real(T)(real(x))
+selfadjoint(::Type{T}, A::AbstractMatrix{<:Number}) where {T<:Real} =
+    Symmetric(convert(AbstractMatrix{T}, A))
+selfadjoint(::Type{T}, A::AbstractMatrix{<:Number}) where {T<:Complex} =
+    Hermitian(convert(AbstractMatrix{T}, A))
+selfadjoint(::Type{T}, F::Factorization) where {T} = convert(Factorization{T}, F)
+selfadjoint(A) = selfadjoint(eltype(A), A)
+selfadjoint(x::Number) = selfadjoint(real(eltype(x)), x)
 
 """
-    selfadjoint(A::AbstractMatrix{<:Complex})
+    rsqrt(A::SelfAdjoint)
 
-Wraps the input in Hermitian. 
-"""
-selfadjoint(A::AbstractMatrix{<:Complex}) = Hermitian(A)
-
-"""
-    rsqrt(A::SelfAdjoint) 
-
-Computes the rigtht square-root of A. 
+Computes the rigtht square-root of A.
 """
 rsqrt(A::SelfAdjoint) = cholesky(A).U
 
 """
-    lsqrt(A::SelfAdjoint) 
+    lsqrt(A::SelfAdjoint)
 
-Computes the left square-root of A. 
+Computes the left square-root of A.
 """
 lsqrt(A::SelfAdjoint) = adjoint(rsqrt(A))
 

--- a/src/generic.jl
+++ b/src/generic.jl
@@ -34,6 +34,9 @@ Random.rand(D::AbstractDistribution) = rand(Random.default_rng(), D)
 
 abstract type AbstractMarkovKernel end
 
+#Random.rand(K::AbstractMarkovKernel, x) = rand(Random.default_rng(), K, x)
+# this is ambiguous w.r.t methods defined in Random.jl ...
+
 abstract type AbstractLikelihood end
 
 for T in (:AbstractDistribution, :AbstractMarkovKernel, :AbstractLikelihood)

--- a/src/kernels/dirackernel.jl
+++ b/src/kernels/dirackernel.jl
@@ -14,34 +14,6 @@ struct DiracKernel{L} <: AbstractDiracKernel
     μ::L
 end
 
-"""
-    DiracKernel(Φ::AbstractMatrix, Σ)
-
-Creates a DiracKernel with a linear conditional mean function given by
-
-    x ↦ Φ * x.
-"""
-DiracKernel(Φ::AbstractMatrix) = DiracKernel(LinearMap(Φ))
-
-"""
-    DiracKernel(Φ::AbstractMatrix, b::AbstractVector, Σ)
-
-Creates a DiracKernel with an affine conditional mean function given by
-
-    x ↦ b + Φ * x.
-"""
-DiracKernel(Φ::AbstractMatrix, b::AbstractVector) = DiracKernel(AffineMap(Φ, b))
-
-"""
-    DiracKernel(Φ::AbstractMatrix, b::AbstractVector, c::AbstractVector, Σ)
-
-Creates a DiracKernel with an affine corrector conditional mean function given by
-
-    x ↦ b + Φ * (x - c).
-"""
-DiracKernel(Φ::AbstractMatrix, b::AbstractVector, c::AbstractVector) =
-    DiracKernel(AffineCorrector(Φ, b, c))
-
 const AffineDiracKernel{T} = DiracKernel{<:AbstractAffineMap{T}} where {T}
 
 """
@@ -87,4 +59,8 @@ function Base.show(io::IO, D::DiracKernel)
     println(io, summary(D))
     println(io, "μ = ")
     show(io, D.μ)
+end
+
+function Base.show(io::IO, D::IdentityKernel)
+    println(io, summary(D))
 end

--- a/test/binary_operations/bayes_rule_test.jl
+++ b/test/binary_operations/bayes_rule_test.jl
@@ -11,12 +11,13 @@ function bayes_rule_test(T, n, m, cov_types, matrix_types)
         C = _make_matrix(Cp, matrix_t)
         y = _make_vector(yp, matrix_t)
         R = _make_covp(_make_matrix(Rp, matrix_t), cov_t)
+        FC = LinearMap(C)
 
         μ = _make_vector(μp, matrix_t)
         Σ = _make_covp(_make_matrix(Vp, matrix_t), cov_t)
         N = Normal(μ, Σ)
 
-        K = NormalKernel(C, R)
+        K = NormalKernel(FC, R)
         L = Likelihood(K, y)
         @testset "bayes_rule | $(nameof(typeof(N))) | $(nameof(typeof(L)))" begin
             M, KC = invert(N, K)
@@ -30,7 +31,7 @@ function bayes_rule_test(T, n, m, cov_types, matrix_types)
             @test NC2 ≈ NC
         end
 
-        K = DiracKernel(C)
+        K = DiracKernel(FC)
         L = Likelihood(K, y)
         @testset "bayes_rule | $(nameof(typeof(N))) | $(nameof(typeof(L)))" begin
             M, KC = invert(N, K)
@@ -67,7 +68,8 @@ function _test_bayes_rule_particle_system(T, n, m)
     P2 = ParticleSystem(copy(logws), copy.(X))
 
     C = randn(T, m, n)
-    K = NormalKernel(C, _symmetrise(T, diagm(ones(T, m))))
+    FC = LinearMap(C)
+    K = NormalKernel(FC, _symmetrise(T, diagm(ones(T, m))))
     y = randn(T, m)
     L = Likelihood(K, y)
     loglike_gt = _loglike(logws, [log(L, X[i]) for i in eachindex(X)])

--- a/test/binary_operations/compose_test.jl
+++ b/test/binary_operations/compose_test.jl
@@ -14,15 +14,15 @@ function compose_test(T, n, cov_types, matrix_types)
         Σ2 = _make_matrix(V2p, matrix_t)
         x = _make_vector(xp, matrix_t)
 
-        NK1 = NormalKernel(A1, _make_covp(Σ1, cov_t))
-        NK2 = NormalKernel(A2, _make_covp(Σ2, cov_t))
+        F1 = LinearMap(A1)
+        F2 = LinearMap(A2)
+        NK1 = NormalKernel(F1, _make_covp(Σ1, cov_t))
+        NK2 = NormalKernel(F2, _make_covp(Σ2, cov_t))
 
-        DK1 = DiracKernel(A1)
-        DK2 = DiracKernel(A2)
+        DK1 = DiracKernel(F1)
+        DK2 = DiracKernel(F2)
 
         IK = IdentityKernel()
-
-        kernel_pairs = ((NK1, NK2), (NK1, DK2), (DK1, NK2), (DK1, DK2))
 
         kernels = (NK1, NK2, DK1, DK2, IK)
 
@@ -62,10 +62,10 @@ function _test_pair_compose(K2::NormalKernel{<:AbstractAffineMap}, K1::AffineDir
     A1, b1 = slope(mean(K1)), intercept(mean(K1))
     K3 = compose(K2, K1)
     @testset "compose | $(nameof(typeof(K2))) | $(nameof(typeof(K1)))" begin
-        @test K3 == K2 ∘ K1 
-        @test slope(mean(K3)) ≈ A2 * A1 
-        @test intercept(mean(K3)) ≈ A2 * b1 + b2 
-        @test covp(K3) == Σ2 
+        @test K3 == K2 ∘ K1
+        @test slope(mean(K3)) ≈ A2 * A1
+        @test intercept(mean(K3)) ≈ A2 * b1 + b2
+        @test covp(K3) == Σ2
     end
 end
 =#

--- a/test/binary_operations/invert_test.jl
+++ b/test/binary_operations/invert_test.jl
@@ -14,15 +14,16 @@ function invert_test(T, n, m, cov_types, matrix_types)
         A = _make_matrix(Ap, matrix_t)
         R = _make_matrix(Rp, matrix_t)
         y = _make_vector(yp, matrix_t)
+        FA = LinearMap(A)
 
         N = Normal(μ, _make_covp(Σ, cov_t))
-        NK = NormalKernel(A, _make_covp(R, cov_t))
-        DK = DiracKernel(A)
+        NK = NormalKernel(FA, _make_covp(R, cov_t))
+        DK = DiracKernel(FA)
         IK = IdentityKernel()
 
         S, G, Π = _schur(Σ, A, R)
         Ngt = Normal(A * μ, S)
-        Kgt = NormalKernel(G, μ, A * μ, Π)
+        Kgt = NormalKernel(AffineCorrector(G, μ, A * μ), Π)
 
         NC, KC = invert(N, NK)
 
@@ -38,7 +39,7 @@ function invert_test(T, n, m, cov_types, matrix_types)
 
         S, G, Π = _schur(Σ, A)
         Ngt = Normal(A * μ, S)
-        Kgt = NormalKernel(G, μ, A * μ, Π)
+        Kgt = NormalKernel(AffineCorrector(G, μ, A * μ), Π)
 
         NC, KC = invert(N, DK)
 

--- a/test/binary_operations/marginalize_test.jl
+++ b/test/binary_operations/marginalize_test.jl
@@ -13,20 +13,21 @@ function marginalize_test(T, n, m, cov_types, matrix_types)
         μ = _make_vector(μp, matrix_t)
         Σ = _make_matrix(Σp, matrix_t)
         A = _make_matrix(Ap, matrix_t)
+        FA = LinearMap(A)
         Q = _make_matrix(Qp, matrix_t)
 
         N = Normal(μ, _make_covp(Σ, cov_t))
         D = Dirac(μ)
-        NK = NormalKernel(A, _make_covp(Q, cov_t))
-        DK = DiracKernel(A)
+        NK = NormalKernel(FA, _make_covp(Q, cov_t))
+        DK = DiracKernel(FA)
         IK = IdentityKernel()
 
-        # marginalize 
+        # marginalize
         for distribution in (N, D), kernel in (NK, DK, IK)
             _test_pair_marginalize(distribution, kernel)
         end
 
-        # plus / minus  
+        # plus / minus
         v = _make_vector(vp, matrix_t)
         for distribution in (N, D)
             @test mean(distribution + v) == mean(v + distribution) == mean(distribution) + v
@@ -34,10 +35,11 @@ function marginalize_test(T, n, m, cov_types, matrix_types)
             @test mean(v - distribution) == v - mean(distribution)
         end
 
-        # multiplication 
+        # multiplication
         C = _make_matrix(Cp, matrix_t)
+        FC = LinearMap(C)
         for distribution in (N, D)
-            @test C * distribution == marginalize(distribution, DiracKernel(C))
+            @test C * distribution == marginalize(distribution, DiracKernel(FC))
         end
     end
 end
@@ -91,7 +93,8 @@ function _test_marginalze_particle_system(T, n, m)
     P = ParticleSystem(logws, X)
 
     C = randn(T, m, n)
-    K = DiracKernel(C)
+    FC = LinearMap(C)
+    K = DiracKernel(FC)
 
     @testset "marginalize | $(typeof(P)) | $(typeof(K))" begin
         @test dim(marginalize(P, K)) == m

--- a/test/kernels/dirackernel_test.jl
+++ b/test/kernels/dirackernel_test.jl
@@ -1,10 +1,4 @@
 function dirackernel_test(T, n, matrix_types)
-    @testset "NormalKernel | AbstractMatrix constructor" begin
-        @test mean(DiracKernel(1.0I(2), ones(2))) == AffineMap(1.0I(2), ones(2))
-        @test mean(DiracKernel(1.0I(2), ones(2), zeros(2))) ==
-              AffineCorrector(1.0I(2), ones(2), zeros(2))
-    end
-
     eltypes = T <: Real ? (Float32, Float64) : (ComplexF32, ComplexF64)
 
     Ap = randn(T, n, n)
@@ -13,7 +7,8 @@ function dirackernel_test(T, n, matrix_types)
     for matrix_t in matrix_types
         A = _make_matrix(Ap, matrix_t)
         x = _make_vector(xp, matrix_t)
-        K = DiracKernel(A)
+        FA = LinearMap(A)
+        K = DiracKernel(FA)
         @testset "AffineDiracKernel | Unary | $(T)" begin
             @test_nowarn repr(K)
 
@@ -23,7 +18,6 @@ function dirackernel_test(T, n, matrix_types)
             @test copy!(similar(K), K) == K
 
             @test typeof(K) <: AffineDiracKernel
-            @test K == DiracKernel(mean(K)...)
             @test convert(typeof(K), K) == K
 
             @test mean(K)(x) == A * x

--- a/test/kernels/normalkernel_test.jl
+++ b/test/kernels/normalkernel_test.jl
@@ -1,7 +1,8 @@
 function normalkernel_test(T)
     A = ones(T, 1, 1)
     Σ = x -> _symmetrise(eltype(x), T.(diagm(exp.(abs.(x)))))
-    K = NormalKernel(A, Σ)
+    F = LinearMap(A)
+    K = NormalKernel(F, Σ)
     x = randn(T, 1)
 
     @testset "NormalKernel | Unary | $(T)" begin
@@ -26,7 +27,8 @@ function affine_normalkernel_test(T, n, cov_types, matrix_types)
         μ = _make_vector(μp, matrix_t)
         Σ = _make_covp(_make_matrix(Vp, matrix_t), cov_t)
         x = _make_vector(xp, matrix_t)
-        K = NormalKernel(A, Σ)
+        F = LinearMap(A)
+        K = NormalKernel(F, Σ)
 
         @testset "AffineNormalKernel | Unary | $(T) | $(cov_t) | $(matrix_t)" begin
             @test_nowarn repr(K)
@@ -37,12 +39,12 @@ function affine_normalkernel_test(T, n, cov_types, matrix_types)
             @test copy!(similar(K), K) == K
 
             @test typeof(K) <: AffineNormalKernel
-            @test K == NormalKernel(mean(K)..., Σ)
-            @test mean(K)(x) == A * x
-            @test _ofsametype(x, A * x)
+            # @test K == NormalKernel(mean(K)..., Σ)
+            @test mean(K)(x) == F(x)
+            @test _ofsametype(x, F(x))
             @test cov(K)(x) == Σ
             @test covp(K) == Σ
-            @test condition(K, x) == Normal(A * x, Σ)
+            @test condition(K, x) == Normal(F(x), Σ)
             @test eltype(rand(K, x)) == T
             @test _ofsametype(μ, rand(K, x))
         end

--- a/test/likelihood_test.jl
+++ b/test/likelihood_test.jl
@@ -11,7 +11,8 @@ function likelihood_test(T, n, m, cov_types, matrix_types)
         y = _make_vector(yp, matrix_t)
         R = _make_covp(_make_matrix(Rp, matrix_t), cov_t)
 
-        K = NormalKernel(C, R)
+        FC = LinearMap(C)
+        K = NormalKernel(FC, R)
         L = Likelihood(K, y)
         @testset "Likelihood | AffineNormal | {$(T),$(cov_t),$(matrix_t)}" begin
             @test L == Likelihood(K, y)
@@ -20,7 +21,7 @@ function likelihood_test(T, n, m, cov_types, matrix_types)
             @test log(L, x) ≈ logpdf(condition(K, x), y)
         end
 
-        K = DiracKernel(C)
+        K = DiracKernel(FC)
         L = Likelihood(K, y)
         @testset "Likelihood | AffineDirac | {$(T),$(cov_t),$(matrix_t)}" begin
             @test L == Likelihood(K, y)

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -54,9 +54,10 @@ cov_types = (HermOrSym, Cholesky)
 
     @testset "compose" begin
         C = [1.0 -1.0]
-        K1 = DiracKernel(C)
+        FC = LinearMap(C)
+        K1 = DiracKernel(FC)
         variance(x) = fill(exp.(x)[1], 1, 1)
-        K2 = NormalKernel(zeros(1, 1), variance)
+        K2 = NormalKernel(LinearMap(zeros(1, 1)), variance)
 
         @testset "compose | $(nameof(typeof(K2))) | $(nameof(typeof(K1)))" begin
             m_kernel = compose(K2, K1)


### PR DESCRIPTION
A draft attempt at fixing #106 

* Remove Matrix/Vector constructors from ```NormalKernel``` and ```DiracKernel``` (now you have to construct an affine map explicitly). 
* add type ```HomoskedasticNormalKernel```  for normal kernels with homoskedastic (constant) conditional covariance. 