### PR TITLE
htransform cleanup 

### DIFF
--- a/src/kernels/normalkernel.jl
+++ b/src/kernels/normalkernel.jl
@@ -49,6 +49,9 @@ const AffineHeteroskedasticNormalKernel{TM,TC} =
     NormalKernel{<:Heteroskedastic,TM,TC} where {TM<:AbstractAffineMap,TC} # affine conditional mean, non-constant covariance
 const NonlinearNormalKernel{TM,TC} = NormalKernel{<:Heteroskedastic,TM,TC} where {TM,TC} # the general, nonlinear case
 
+const AffineIsotropicNormalKernel{TM,TC} =
+    NormalKernel{<:Homoskedastic,TM,TC} where {TM<:AbstractAffineMap,TC<:UniformScaling}
+
 """
     mean(K::AbstractNormalKernel)
 

--- a/src/likelihoods/logquadratic.jl
+++ b/src/likelihoods/logquadratic.jl
@@ -32,6 +32,20 @@ function LogQuadraticLikelihood(L::Likelihood{<:AffineHomoskedasticNormalKernel}
     return LogQuadraticLikelihood(logc, ybar, Cbar)
 end
 
+# fix for missing Method: \(::UniformScaling, ::Number)
+function LogQuadraticLikelihood(L::Likelihood{<:AffineIsotropicNormalKernel})
+    K, y = measurement_model(L), measurement(L)
+    T = eltype(y)
+    F = mean(K)
+    Rsqrt = lsqrt(covp(K)).λ # typeof(Rsqrt) <: UniformScaling 
+    m = length(y)
+
+    ybar = Rsqrt \ (y - intercept(F))
+    Cbar = Rsqrt \ slope(F)
+    logc = -_nscale(T) * (m * _logpiconst(T) + 2 * logdet(Rsqrt))
+    return LogQuadraticLikelihood(logc, ybar, Cbar)
+end
+
 logconstant(L::LogQuadraticLikelihood) = L.logconst
 
 observation(L::LogQuadraticLikelihood) = L.y

--- a/test/binary_operations/htransform_test.jl
+++ b/test/binary_operations/htransform_test.jl
@@ -115,7 +115,7 @@
             L2 = Likelihood(K2, y2)
 
             # exclude L2 for now since \(::UniformScaling, ::Number) is not implemented?
-            Ls = (L1,)
+            Ls = (L1, L2)
             for L in Ls
                 N = condition(K, x0)
                 NCgt, llgt = posterior_and_loglike(N, L)


### PR DESCRIPTION
 
* refactor ```schur_reduce``` to make $K  S^{1/2}$ more easily obtainable 
* use above to make ```htransform``` more efficient when the input kernel is Cholesky parametrized
* fix bug in ```LogQuadraticLikelihood``` constructor due to missing method for ```\(::UniformScaling, ::Number)```